### PR TITLE
FIX downgrade MongoDB versión from 5.0 to 4.2 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   mongo1:
-    image: mongo:5
+    image: mongo:4.2
     container_name: mongo1
     command: ['mongod', '--replSet', 'Replica_UOC', '--bind_ip', 'localhost,mongo1', '--port', '27018']
     restart: always
@@ -12,7 +12,7 @@ services:
     volumes:
       - volume-mongo1:/data/db
   mongo2:
-    image: mongo:5
+    image: mongo:4.2
     container_name: mongo2
     command: ['mongod', '--replSet', 'Replica_UOC', '--bind_ip', 'localhost,mongo2', '--port', '27019']
     restart: always
@@ -23,7 +23,7 @@ services:
     volumes:
       - volume-mongo2:/data/db
   mongo3:
-    image: mongo:5
+    image: mongo:4.2
     container_name: mongo3
     command: ['mongod', '--replSet', 'Replica_UOC', '--bind_ip', 'localhost,mongo3', '--port', '27020']
     restart: always


### PR DESCRIPTION
Although MongoDB 5.0 is newer than 4.2, in some old PCs it may lead to this error:

> "WARNING: MongoDB 5.0+ requires a CPU with AVX support, and your current system does not appear to have that!"

From a learning point of view, 4.2 suffices, so maybe it is wise to downgrade the version, as this pull request does.